### PR TITLE
Chore: Update to rs-crypto-types v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -336,9 +336,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "crypto-layer"
 version = "0.1.0"
-source = "git+https://github.com/nmshd/rust-crypto.git#7ad4abb7e5f922802c727f3f43213496bf7e428d"
+source = "git+https://github.com/nmshd/rust-crypto.git#4e3f7506424ff14256238734e198708ac4e7e5fe"
 dependencies = [
  "anyhow",
  "argon2",
@@ -576,6 +576,12 @@ dependencies = [
  "ct-codecs",
  "getrandom 0.2.16",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -876,19 +882,39 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
+name = "linkme"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -935,12 +961,14 @@ dependencies = [
 
 [[package]]
 name = "neon"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d75440242411c87dc39847b0e33e961ec1f10326a9d8ecf9c1ea64a3b3c13dc"
+checksum = "74c1d298c79e60a3f5a1e638ace1f9c1229d2a97bd3a9e40a63b67c8efa0f1e1"
 dependencies = [
+ "either",
  "getrandom 0.2.16",
  "libloading",
+ "linkme",
  "neon-macros",
  "once_cell",
  "semver",
@@ -951,13 +979,13 @@ dependencies = [
 
 [[package]]
 name = "neon-macros"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6813fde79b646e47e7ad75f480aa80ef76a5d9599e2717407961531169ee38b"
+checksum = "c39e43767817fc963f90f400600967a2b2403602c6440685d09a6bc4e02b70b1"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.101",
- "syn-mid",
 ]
 
 [[package]]
@@ -1303,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34bc6763177194266fc3773e2b2bb3693f7b02fdf461e285aa33202e3164b74e"
+checksum = "cef6a6d3a65ea334d6cdfb31fa2525c20184b7aa7bd1ad1e2e37502610d4609f"
 dependencies = [
  "libc",
 ]
@@ -1453,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1700,17 +1728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-mid"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5dc35bb08dd1ca3dfb09dce91fd2d13294d6711c88897d9a9d60acf39bce049"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "pin-project-lite",

--- a/crates/crypto-layer-node/src/fromjs/config.rs
+++ b/crates/crypto-layer-node/src/fromjs/config.rs
@@ -131,11 +131,13 @@ pub(crate) fn from_wrapped_key_spec(
     let cipher_js = js_result(wrapped.get(cx, "cipher"))?;
     let signing_hash_js = js_result(wrapped.get(cx, "signing_hash"))?;
     let ephemeral_js = js_result(wrapped.get::<JsBoolean, _, _>(cx, "ephemeral"))?;
+    let non_exportable_js = js_result(wrapped.get::<JsBoolean, _, _>(cx, "non_exportable"))?;
 
     Ok(KeySpec {
         cipher: from_wrapped_simple_enum(cx, cipher_js)?,
         signing_hash: from_wrapped_simple_enum(cx, signing_hash_js)?,
         ephemeral: ephemeral_js.value(cx),
+        non_exportable: non_exportable_js.value(cx),
     })
 }
 

--- a/crates/crypto-layer-node/src/keypairhandle.rs
+++ b/crates/crypto-layer-node/src/keypairhandle.rs
@@ -118,7 +118,6 @@ pub fn export_delete(mut cx: FunctionContext) -> JsResult<JsPromise> {
 ///
 /// # Arguments
 /// * **data**: `Uint8Array`
-/// * **signature**: `Uint8Array`
 ///
 /// # Returns
 /// * `boolean` - on success
@@ -129,13 +128,11 @@ pub fn export_encrypt_data(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let handle_arc = (**cx.this::<JsKeyPairHandle>()?).clone();
     let data_js = cx.argument::<JsUint8Array>(0)?;
     let data = vec_from_uint_8_array(&mut cx, data_js);
-    let iv_js = cx.argument::<JsUint8Array>(1)?;
-    let iv = vec_from_uint_8_array(&mut cx, iv_js);
 
     spawn_promise(&mut cx, move |channel, deferred| {
         let handle = arc_or_poisoned_error_deferred!(&channel, deferred, handle_arc.read());
 
-        let encrypted_data = handle.encrypt_data(&data, &iv);
+        let encrypted_data = handle.encrypt_data(&data);
 
         deferred.settle_with(&channel, |mut cx| {
             let encrypted_data = unwrap_or_throw!(cx, encrypted_data);

--- a/crates/crypto-layer-node/src/tojs/config.rs
+++ b/crates/crypto-layer-node/src/tojs/config.rs
@@ -77,6 +77,8 @@ pub fn wrap_key_spec<'a>(cx: &mut impl Context<'a>, spec: KeySpec) -> JsResult<'
     insert_as_js_str_into_obj!(cx, obj, spec.signing_hash);
     let ephemeral_js = cx.boolean(spec.ephemeral);
     obj.set(cx, "ephemeral", ephemeral_js)?;
+    let non_exportable_js = cx.boolean(spec.non_exportable);
+    obj.set(cx, "non_exportable", non_exportable_js)?;
 
     Ok(obj)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nmshd/rs-crypto-node",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nmshd/rs-crypto-node",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@neon-rs/load": "^0.1.73",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@neon-rs/load": "^0.1.73",
-        "@nmshd/rs-crypto-types": "^0.9.0"
+        "@nmshd/rs-crypto-types": "^0.10.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -29,10 +29,10 @@
         "typescript-eslint": "^8.25.0"
       },
       "optionalDependencies": {
-        "@nmshd/rs-crypto-node-darwin-arm64": "0.11.0",
-        "@nmshd/rs-crypto-node-darwin-x64": "0.11.0",
-        "@nmshd/rs-crypto-node-linux-x64-gnu": "0.11.0",
-        "@nmshd/rs-crypto-node-win32-x64-msvc": "0.11.0"
+        "@nmshd/rs-crypto-node-darwin-arm64": "0.12.1",
+        "@nmshd/rs-crypto-node-darwin-x64": "0.12.1",
+        "@nmshd/rs-crypto-node-linux-x64-gnu": "0.12.1",
+        "@nmshd/rs-crypto-node-win32-x64-msvc": "0.12.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1393,9 +1393,9 @@
       "license": "MIT"
     },
     "node_modules/@nmshd/rs-crypto-node-darwin-arm64": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-node-darwin-arm64/-/rs-crypto-node-darwin-arm64-0.11.0.tgz",
-      "integrity": "sha512-FmbkQ9X9GT6XZ4LUnujevQtWIaVl4b0do27GxnoZoOVcOKn/OiBYRlXLjMdEuyhIFA6vu7z370kcDSWhuL+F1g==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-node-darwin-arm64/-/rs-crypto-node-darwin-arm64-0.12.1.tgz",
+      "integrity": "sha512-JqoB5FAHJXWuhR62p8xxjM84CFKJt/52nb+lujxE7aC7m8SkzEYmMcY56UUD8VaNj9QjeN012Ee8HT2JSf1mbQ==",
       "cpu": [
         "arm64"
       ],
@@ -1406,9 +1406,9 @@
       ]
     },
     "node_modules/@nmshd/rs-crypto-node-darwin-x64": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-node-darwin-x64/-/rs-crypto-node-darwin-x64-0.11.0.tgz",
-      "integrity": "sha512-vIbwO/3uFVldo8BE0ONI9tKhKYTZqgYjaUCxrDjGGX14H0SIryGUPR3ZLTdfAMOAnpSgNccsHbRIbXZ1xmxhQA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-node-darwin-x64/-/rs-crypto-node-darwin-x64-0.12.1.tgz",
+      "integrity": "sha512-ZgN1rWOFuWOGhll5O+ju/UXtiE9BqLEgXmXYlO/05JRFHhbGBIHXaEF/aplUpcI6mr6tulzqfLwT1RHjfR3c0g==",
       "cpu": [
         "x64"
       ],
@@ -1419,9 +1419,9 @@
       ]
     },
     "node_modules/@nmshd/rs-crypto-node-linux-x64-gnu": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-node-linux-x64-gnu/-/rs-crypto-node-linux-x64-gnu-0.11.0.tgz",
-      "integrity": "sha512-hi9oS8i9YPFyraK6vrUBgqkarImr+Gx6n4nXxJfJZluAjMIPje4y62EN+bGSBFRIGFAP0lipcWdmjYrbNAX7ag==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-node-linux-x64-gnu/-/rs-crypto-node-linux-x64-gnu-0.12.1.tgz",
+      "integrity": "sha512-VP506AOvc30S7tajxPg0wU1ikjX+unJA0fHy+sX6D5sFNWHbciJahFVpfOPApvuG04hdBHbT3E+Vw5pgWwO51Q==",
       "cpu": [
         "x64"
       ],
@@ -1432,9 +1432,9 @@
       ]
     },
     "node_modules/@nmshd/rs-crypto-node-win32-x64-msvc": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-node-win32-x64-msvc/-/rs-crypto-node-win32-x64-msvc-0.11.0.tgz",
-      "integrity": "sha512-3ufWy/QUaJ4lwQMhM0B3o9sghSvq49MW+0ubQONSZSWYYXDDN2s3AF9MmjGLynD4/RdHVs8Ossts0jkxuEuZbA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-node-win32-x64-msvc/-/rs-crypto-node-win32-x64-msvc-0.12.1.tgz",
+      "integrity": "sha512-VxixKbixKLevaOY3tsqbXa2CkFvEA+GSz9DBDU8Kwdgu1MStvJcwEdkHTFDQx8P6blkac9AHSgCT9RZ5ZQzHHw==",
       "cpu": [
         "x64"
       ],
@@ -1445,9 +1445,9 @@
       ]
     },
     "node_modules/@nmshd/rs-crypto-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-types/-/rs-crypto-types-0.9.0.tgz",
-      "integrity": "sha512-gXnrqX+5CzKFgR8CspQhQgD06/TMJZJc/w58ZLt2aRXQbZy0voET/2o0RVoTi6OsmVmbeKuh68uMQVVv66aVjQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@nmshd/rs-crypto-types/-/rs-crypto-types-0.10.0.tgz",
+      "integrity": "sha512-TVWL0oxbyl+6M8eM/cdLMywZTeGBDseIETYddkn+Q6Am+WUOD1QcB43FJKri1R5W0oh+61My5jynD+9l1X+Pug==",
       "license": "MIT",
       "dependencies": {
         "typia": "^8.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nmshd/rs-crypto-node",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "crypto layer ts interface for nodejs",
   "homepage": "https://enmeshed.eu",
   "repository": "github:nmshd/crypto-layer-node",
@@ -65,9 +65,9 @@
     "@nmshd/rs-crypto-types": "^0.10.0"
   },
   "optionalDependencies": {
-    "@nmshd/rs-crypto-node-darwin-arm64": "0.12.1",
-    "@nmshd/rs-crypto-node-darwin-x64": "0.12.1",
-    "@nmshd/rs-crypto-node-linux-x64-gnu": "0.12.1",
-    "@nmshd/rs-crypto-node-win32-x64-msvc": "0.12.1"
+    "@nmshd/rs-crypto-node-darwin-arm64": "0.13.0",
+    "@nmshd/rs-crypto-node-darwin-x64": "0.13.0",
+    "@nmshd/rs-crypto-node-linux-x64-gnu": "0.13.0",
+    "@nmshd/rs-crypto-node-win32-x64-msvc": "0.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@neon-rs/load": "^0.1.73",
-    "@nmshd/rs-crypto-types": "^0.9.0"
+    "@nmshd/rs-crypto-types": "^0.10.0"
   },
   "optionalDependencies": {
     "@nmshd/rs-crypto-node-darwin-arm64": "0.12.1",

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -2,7 +2,7 @@
     "name": "@nmshd/rs-crypto-node-darwin-arm64",
     "description": "Prebuilt binary package for `rs-crypto-node` on `darwin-arm64`.",
     "repository": "github:nmshd/crypto-layer-node",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "os": [
         "darwin"
     ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -2,7 +2,7 @@
     "name": "@nmshd/rs-crypto-node-darwin-x64",
     "description": "Prebuilt binary package for `rs-layer-ts` on `darwin-x64`.",
     "repository": "github:nmshd/crypto-layer-node",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "os": [
         "darwin"
     ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -2,7 +2,7 @@
     "name": "@nmshd/rs-crypto-node-linux-arm64-gnu",
     "description": "Prebuilt binary package for `rs-layer-ts` on `linux-arm64-gnu`.",
     "repository": "github:nmshd/crypto-layer-node",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "os": [
         "linux"
     ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -2,7 +2,7 @@
     "name": "@nmshd/rs-crypto-node-linux-x64-gnu",
     "description": "Prebuilt binary package for `rs-layer-ts` on `linux-x64-gnu`.",
     "repository": "github:nmshd/crypto-layer-node",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "os": [
         "linux"
     ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -2,7 +2,7 @@
     "name": "@nmshd/rs-crypto-node-win32-x64-msvc",
     "description": "Prebuilt binary package for `rs-layer-ts` on `win32-x64-msvc`.",
     "repository": "github:nmshd/crypto-layer-node",
-    "version": "0.12.1",
+    "version": "0.13.0",
     "os": [
         "win32"
     ],

--- a/src/index.cts
+++ b/src/index.cts
@@ -170,7 +170,6 @@ declare module "./load.cjs" {
     function encryptDataForKeyPairHandle(
         this: BareKeyPairHandle,
         data: Uint8Array,
-        iv: Uint8Array,
     ): Promise<Uint8Array>;
     function decryptDataForKeyPairHandle(
         this: BareKeyPairHandle,
@@ -449,12 +448,8 @@ class NodeKeyPairHandle implements KeyPairHandle {
         return await verifySignature.call(this.keyPairHandle, data, signature);
     }
 
-    async encryptData(data: Uint8Array, iv: Uint8Array): Promise<Uint8Array> {
-        return await encryptDataForKeyPairHandle.call(
-            this.keyPairHandle,
-            data,
-            iv,
-        );
+    async encryptData(data: Uint8Array): Promise<Uint8Array> {
+        return await encryptDataForKeyPairHandle.call(this.keyPairHandle, data);
     }
 
     async decryptData(encryptedData: Uint8Array): Promise<Uint8Array> {

--- a/tests/key-handle.test.ts
+++ b/tests/key-handle.test.ts
@@ -32,6 +32,7 @@ describe("test key handle methods", () => {
         cipher: "AesGcm256",
         signing_hash: "Sha2_256",
         ephemeral: false,
+        non_exportable: true,
     };
 
     test("id", async () => {
@@ -152,5 +153,10 @@ describe("test key handle methods", () => {
         });
         expect(typeof (await derived.spec())).toEqual("object");
         expect(typeof (await derived2.spec())).toEqual("object");
+    });
+
+    test("extraction of non exportable key handle fails", async () => {
+        const key = await provider.createKey(spec);
+        expect(key.extractKey()).rejects.toThrow();
     });
 });

--- a/tests/key-handle.test.ts
+++ b/tests/key-handle.test.ts
@@ -142,5 +142,15 @@ describe("test key handle methods", () => {
         const decrypted = derived2.decryptData(...cipher);
 
         expect(decrypted).resolves.toEqual(payload);
+        expect(derived.spec()).resolves.toEqual({
+            ...(await key.spec()),
+            ephemeral: true,
+        });
+        expect(derived2.spec()).resolves.toEqual({
+            ...(await key.spec()),
+            ephemeral: true,
+        });
+        expect(typeof (await derived.spec())).toEqual("object");
+        expect(typeof (await derived2.spec())).toEqual("object");
     });
 });

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -39,6 +39,7 @@ describe("test provider methods", () => {
             cipher: "AesGcm256",
             signing_hash: "Sha2_256",
             ephemeral: true,
+            non_exportable: true,
         };
 
         const key = await provider.createKey(spec);
@@ -58,6 +59,7 @@ describe("test provider methods", () => {
                 cipher: "AesGcm256",
                 signing_hash: "Sha2_256",
                 ephemeral: true,
+                non_exportable: true,
             };
 
             const key = await provider.createKey(spec);
@@ -75,6 +77,7 @@ describe("test provider methods", () => {
                 cipher: "AesGcm256",
                 signing_hash: "Sha2_256",
                 ephemeral: false,
+                non_exportable: true,
             };
 
             const key = await provider.createKey(spec);
@@ -265,6 +268,7 @@ describe("test provider methods", () => {
             cipher: "AesGcm256",
             signing_hash: "Sha2_256",
             ephemeral: true,
+            non_exportable: true,
         };
 
         const kdf: KDF = {
@@ -283,31 +287,6 @@ describe("test provider methods", () => {
             spec,
             kdf,
         );
-        expect(keyHandle).toBeDefined();
-        expect(keyHandle.spec).toBeDefined();
-        expect(keyHandle.spec()).resolves.toEqual(spec);
-    });
-
-    test("derive key from base", async () => {
-        const spec: KeySpec = {
-            cipher: "AesGcm256",
-            signing_hash: "Sha2_256",
-            ephemeral: true,
-        };
-
-        const baseKeyHandle = await provider.createKey(spec);
-        const baseKey = await baseKeyHandle.extractKey();
-
-        const keyId = 12345678;
-        const context = "bees fly";
-
-        const keyHandle = await provider.deriveKeyFromBase(
-            baseKey,
-            keyId,
-            context,
-            spec,
-        );
-
         expect(keyHandle).toBeDefined();
         expect(keyHandle.spec).toBeDefined();
         expect(keyHandle.spec()).resolves.toEqual(spec);


### PR DESCRIPTION

### Changed
* Removed iv argument from `encrypt_data` method of `KeyPairHandle`.
* Added `non_exportable` flag to `KeySpec`.
* Updated tests.
